### PR TITLE
[chore] Export a single instance of LD and DVC api wrappers

### DIFF
--- a/src/api/DevcycleApiWrapper.ts
+++ b/src/api/DevcycleApiWrapper.ts
@@ -9,7 +9,7 @@ export default class DevCycleApiWrapper {
     dvcClientSecret: string
     apiToken: string
 
-    async getApiToken(): Promise<string> {
+    private async getApiToken(): Promise<string> {
         if (this.apiToken) return this.apiToken
         const response = await fetch("https://auth.devcycle.com/oauth/token", {
             method: "POST",
@@ -28,40 +28,39 @@ export default class DevCycleApiWrapper {
         return data.access_token;
     };
 
-    async getProject(projectKey: string) {
+    private async getHeaders() {
         const token = await this.getApiToken()
+        return {
+            Authorization: token,
+            'Content-Type': 'application/json'
+        }
+    }
+
+    async getProject(projectKey: string) {
+        const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}`, {
             method: "GET",
-            headers: {
-                Authorization: token,
-                'Content-Type': 'application/json'
-            },
+            headers,
         });
         return response.json();
     }
 
     async createProject(payload: Record<string, string>) {
-        const token = await this.getApiToken()
+        const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects`, {
             method: "POST",
             body: JSON.stringify(payload),
-            headers: {
-                Authorization: token,
-                'Content-Type': 'application/json'
-            },
+            headers,
         });
         return response.json();
     }
 
     async updateProject (projectKey: string, payload: Record<string, string>) {
-        const token = await this.getApiToken()
+        const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}`, {
             method: "PATCH",
             body: JSON.stringify(payload),
-            headers: {
-                Authorization: token,
-                'Content-Type': 'application/json'
-            },
+            headers,
         });
         return response.json();
     }

--- a/src/api/LDApiWrapper.ts
+++ b/src/api/LDApiWrapper.ts
@@ -6,23 +6,28 @@ export default class LDApiWrapper {
     }
     apiToken: string
 
+    private async getHeaders() {
+        return {
+            Authorization: this.apiToken,
+        }
+    }
+
+
     async getProject(project_key: string) {
+        const headers = await this.getHeaders()
         const response = await fetch(`${LD_BASE_URL}/projects/${project_key}`, {
             method: "GET",
-            headers: {
-                Authorization: this.apiToken,
-            },
+            headers,
         });
         const data = await response.json();
         return data;
     }
     
     async getFeatureFlagsForProject(project_key: string) {
+        const headers = await this.getHeaders()
         const response = await fetch(`${LD_BASE_URL}/flags/${project_key}`, {
             method: "GET",
-            headers: {
-                Authorization: this.apiToken,
-            },
+            headers
         });
         const data = await response.json();
         return data;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import { getConfigs } from '../configs'
+import DVCApiWrapper from './DevcycleApiWrapper'
+import LDApiWrapper from './LDApiWrapper'
+
+const config = getConfigs()
+export const LD = new LDApiWrapper(config.ldAccessToken)
+export const DVC = new DVCApiWrapper(config.dvcClientId, config.dvcClientSecret)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 import { getConfigs } from './configs'
-import DVCApiWrapper from './api/DevcycleApiWrapper'
-import LDApiWrapper from './api/LDApiWrapper'
+import { LD, DVC } from './api'
 
 const config = getConfigs()
-const LD = new LDApiWrapper(config.ldAccessToken)
-const DVC = new DVCApiWrapper(config.dvcClientId, config.dvcClientSecret)
 
 async function populateProject() {
     const ldProject = await LD.getProject(config.projectKey)


### PR DESCRIPTION
- Export a single instance of api wrapper so that it doesn't need to be recreated or passed as a parameter
- Create method to build headers