### PR TITLE
[refactor] Update api wrapper to add throwOnError option

### DIFF
--- a/src/api/DevcycleApiWrapper.ts
+++ b/src/api/DevcycleApiWrapper.ts
@@ -1,4 +1,14 @@
+import { handleErrors } from './utils'
+
 const DVC_BASE_URL = "https://api.devcycle.com/v1";
+
+type Options = {
+    throwOnError: boolean
+}
+
+const defaultOptions = {
+    throwOnError: true
+}
 
 export default class DevCycleApiWrapper {
     constructor(dvcClientId: string, dvcClientSecret: string) {
@@ -36,32 +46,43 @@ export default class DevCycleApiWrapper {
         }
     }
 
-    async getProject(projectKey: string) {
+    private async handleErrors(response: Response) {
+        await handleErrors('Error calling DevCycle API', response)
+    }
+
+    async getProject(projectKey: string, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}`, {
             method: "GET",
             headers,
         });
+        if (options.throwOnError) await this.handleErrors(response)
         return response.json();
     }
 
-    async createProject(payload: Record<string, string>) {
+    async createProject(payload: Record<string, string>, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects`, {
             method: "POST",
             body: JSON.stringify(payload),
             headers,
         });
+        if (options.throwOnError) await this.handleErrors(response)
         return response.json();
     }
 
-    async updateProject (projectKey: string, payload: Record<string, string>) {
+    async updateProject (
+        projectKey: string,
+        payload: Record<string, string>,
+        options: Options = defaultOptions
+    ) {
         const headers = await this.getHeaders()
         const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}`, {
             method: "PATCH",
             body: JSON.stringify(payload),
             headers,
         });
+        if (options.throwOnError) await this.handleErrors(response)
         return response.json();
     }
 }

--- a/src/api/LDApiWrapper.ts
+++ b/src/api/LDApiWrapper.ts
@@ -1,4 +1,14 @@
+import { handleErrors } from "./utils";
+
 const LD_BASE_URL = "https://app.launchdarkly.com/api/v2";
+
+type Options = {
+    throwOnError: boolean
+}
+
+const defaultOptions = {
+    throwOnError: true
+}
 
 export default class LDApiWrapper {
     constructor(apiToken: string) {
@@ -12,24 +22,27 @@ export default class LDApiWrapper {
         }
     }
 
+    private async handleErrors(response: Response) {
+        await handleErrors('Error calling LaunchDarkly API', response)
+    }
 
-    async getProject(project_key: string) {
+    async getProject(project_key: string, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
         const response = await fetch(`${LD_BASE_URL}/projects/${project_key}`, {
             method: "GET",
             headers,
         });
-        const data = await response.json();
-        return data;
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
     }
     
-    async getFeatureFlagsForProject(project_key: string) {
+    async getFeatureFlagsForProject(project_key: string, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
         const response = await fetch(`${LD_BASE_URL}/flags/${project_key}`, {
             method: "GET",
-            headers
+            headers,
         });
-        const data = await response.json();
-        return data;
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
     }
 }

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,0 +1,6 @@
+export async function handleErrors(prefix: string, response: Response) {
+    if (!response.ok) {
+        const body = await response.json()
+        throw Error(`${prefix}: ${body.message || response.statusText}`);
+    }
+}

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -49,7 +49,7 @@ const getOptionalBoolean = (value: string | undefined): boolean => {
     return JSON.parse(value)
 }
 
-type DVCImporterConfigs = {
+export type DVCImporterConfigs = {
     // LaunchDarkly access token, used for pulling feature flags
     ldAccessToken: string,
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,10 @@
 import { getConfigs } from './configs'
-import { LD, DVC } from './api'
+import { importProject } from './resources/project'
 
 const config = getConfigs()
 
-async function populateProject() {
-    const ldProject = await LD.getProject(config.projectKey)
-    const dvcProject = await DVC.getProject(config.projectKey)
-
-    const isDuplicate = Boolean(dvcProject._id)
-
-    const projectPayload = {
-        name: ldProject.name,
-        key: ldProject.key
-    }
-
-    let response
-    if (!isDuplicate) {
-        response = await DVC.createProject(projectPayload)
-        console.log(`Creating project "${projectPayload.key}" in DevCycle`)
-    } else if (config.overwriteDuplicates) {
-        response = await DVC.updateProject(config.projectKey, projectPayload)
-        console.log(`Updating project "${config.projectKey}" in DevCycle`)
-    } else {
-        console.log('Skipping project creation because it already exists')
-    }
-
-    if (response?.statusCode) {
-        console.log(response)
-        throw new Error('Error creating project')
-    }
-
-    return {
-        dvcProject: response,
-        ldProject
-    }
-}
-
 async function run() {
-    await populateProject()
+    await importProject(config)
 }
 
 run()

--- a/src/resources/project.ts
+++ b/src/resources/project.ts
@@ -1,0 +1,30 @@
+import { LD, DVC } from '../api'
+import { DVCImporterConfigs } from '../configs'
+
+export async function importProject(config: DVCImporterConfigs) {
+    const ldProject = await LD.getProject(config.projectKey)
+    const dvcProject = await DVC.getProject(config.projectKey, { throwOnError: false })
+
+    const isDuplicate = Boolean(dvcProject._id)
+
+    const projectPayload = {
+        name: ldProject.name,
+        key: ldProject.key
+    }
+
+    let response
+    if (!isDuplicate) {
+        response = await DVC.createProject(projectPayload)
+        console.log(`Creating project "${projectPayload.key}" in DevCycle`)
+    } else if (config.overwriteDuplicates) {
+        response = await DVC.updateProject(config.projectKey, projectPayload)
+        console.log(`Updating project "${config.projectKey}" in DevCycle`)
+    } else {
+        console.log('Skipping project creation because it already exists')
+    }
+
+    return {
+        dvcProject: response,
+        ldProject
+    }
+}


### PR DESCRIPTION
Add `throwOnError` option to api wrappers, defaults to true. This removes the need for each method to handle throwing, but we can prevent an error from being thrown when necessary (ie. project 404)