### PR TITLE
[feat] Add basic support for mapping segments to audiences

### DIFF
--- a/src/api/DevcycleApiWrapper.ts
+++ b/src/api/DevcycleApiWrapper.ts
@@ -85,4 +85,45 @@ export default class DevCycleApiWrapper {
         if (options.throwOnError) await this.handleErrors(response)
         return response.json();
     }
+
+    async getAudiences(projectKey: string, options: Options = defaultOptions) {
+        const headers = await this.getHeaders()
+        const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}/audiences`, {
+            method: 'GET',
+            headers,
+        });
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
+    }
+
+    async createAudience(
+        projectKey: string,
+        payload: Record<string, string>,
+        options: Options = defaultOptions
+    ) {
+        const headers = await this.getHeaders()
+        const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}/audiences`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+            headers,
+        })
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
+    }
+
+    async updateAudience (
+        projectKey: string,
+        audienceKey: string,
+        payload: Record<string, string>,
+        options: Options = defaultOptions
+    ) {
+        const headers = await this.getHeaders()
+        const response = await fetch(`${DVC_BASE_URL}/projects/${projectKey}/audiences/${audienceKey}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload),
+            headers,
+        })
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
+    }
 }

--- a/src/api/LDApiWrapper.ts
+++ b/src/api/LDApiWrapper.ts
@@ -26,22 +26,32 @@ export default class LDApiWrapper {
         await handleErrors('Error calling LaunchDarkly API', response)
     }
 
-    async getProject(project_key: string, options: Options = defaultOptions) {
+    async getProject(projectKey: string, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
-        const response = await fetch(`${LD_BASE_URL}/projects/${project_key}`, {
-            method: "GET",
+        const response = await fetch(`${LD_BASE_URL}/projects/${projectKey}?expand=environments`, {
+            method: 'GET',
             headers,
-        });
+        })
+        if (options.throwOnError) await this.handleErrors(response)
+        return response.json()
+    }
+
+    async getSegments(projectKey: string, environmentKey: string, options: Options = defaultOptions) {
+        const headers = await this.getHeaders()
+        const response = await fetch(`${LD_BASE_URL}/segments/${projectKey}/${environmentKey}`, {
+            method: 'GET',
+            headers,
+        })
         if (options.throwOnError) await this.handleErrors(response)
         return response.json()
     }
     
-    async getFeatureFlagsForProject(project_key: string, options: Options = defaultOptions) {
+    async getFeatureFlagsForProject(projectKey: string, options: Options = defaultOptions) {
         const headers = await this.getHeaders()
-        const response = await fetch(`${LD_BASE_URL}/flags/${project_key}`, {
-            method: "GET",
+        const response = await fetch(`${LD_BASE_URL}/flags/${projectKey}`, {
+            method: 'GET',
             headers,
-        });
+        })
         if (options.throwOnError) await this.handleErrors(response)
         return response.json()
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 import { getConfigs } from './configs'
+import { importAudiences } from './resources/audiences'
 import { importProject } from './resources/project'
 
 const config = getConfigs()
 
 async function run() {
-    await importProject(config)
-}
+    const { ldProject } = await importProject(config)
 
+    const ldEnvironments = ldProject.environments.items
+    const environmentKeys = ldEnvironments.map((env: Record<string, any>) => env.key)
+    const {
+        audiencesByKey,
+        unsupportedAudiencesByKey
+    } = await importAudiences(config, environmentKeys)
+}
 run()
 

--- a/src/resources/audiences.ts
+++ b/src/resources/audiences.ts
@@ -1,0 +1,47 @@
+import { LD, DVC } from '../api'
+import { DVCImporterConfigs } from '../configs'
+
+
+export async function importAudiences(config: DVCImporterConfigs, environmentKeys: string[]) {
+    const unsupportedAudiencesByKey: Record<string, string> = {};
+    const audiencesByKey = await DVC.getAudiences(config.projectKey).then((audiences) => (
+        audiences.reduce((map: Record<string, any>, audience: Record<string, any>) => {
+            map[audience.key] = audience
+            return map
+        }, {})
+    ))
+    for (const environmentKey of environmentKeys) {
+        const ldSegments = await LD.getSegments(config.projectKey, environmentKey)
+
+        for (const segment of ldSegments.items) {
+            const key = `${segment.key}-${environmentKey}`
+            const isDuplicate = Boolean(audiencesByKey[key])
+
+            const audiencePayload = {
+                name: segment.name,
+                key,
+                description: segment.description,
+                tags: segment.tags,
+                filters: segment.rules.map(mapRuleToFilter)
+            }
+
+            if (!isDuplicate) {
+                console.log(`Creating audience "${key}" in DevCycle`)
+                audiencesByKey[key] = await DVC.createAudience(config.projectKey, audiencePayload)
+            } else if (config.overwriteDuplicates) {
+                console.log(`Updating audience "${key}" in DevCycle`)
+                audiencesByKey[key] = await DVC.updateAudience(config.projectKey, key, audiencePayload)
+            } else {
+                console.log('Skipping audience creation because it already exists')
+            }
+        }
+    }
+    return {
+        audiencesByKey,
+        unsupportedAudiencesByKey
+    }
+}
+
+function mapRuleToFilter(rule: Record<string, any>) {
+    // TODO: map rules to filters
+}


### PR DESCRIPTION
Create DVC audiences from LD segments

Split into additional tickets to reduce the size of this PR:
- Create audience filters from segment rules
- Skip segments that contain attribute "segmentMatch"