### PR TITLE
[feat] add support for before/after ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 DevCycle's Feature Importer is designed to import resources from other feature flag providers. 
 The importer is intended to be run on a single project and will create or update a project with the same key containing Environments, Features, and Variables. 
 
+## Table of Contents
+- [Setup](#setup)
+- [Configuration](#configuration)
+  - [Required](#required)
+  - [Optional](#optional)
+- [Changes Necessary when Migrating Code](#changes-necessary-when-migrating-code)
+
 ## Setup
 1. Run `yarn` to install dependencies
 2. Setup [configuration file](#configuration)
@@ -63,3 +70,6 @@ INCLUDE_FEATURES=["feat-1"]
 EXCLUDE_FEATURES=[]
 OVERWRITE_DUPLICATES=false
 ```
+
+## Changes Necessary when Migrating Code
+- For rules where the attribute is a date and using the before/after operators, the value needs to be converted to a long instead of sending as a date.

--- a/src/utils/LaunchDarkly/targeting.ts
+++ b/src/utils/LaunchDarkly/targeting.ts
@@ -37,6 +37,8 @@ export function getComparator(clause: Clause) {
         greaterThan: (neg: boolean) => '>',
         greaterThanOrEqual: (neg: boolean) => '>=',
         segmentMatch: (neg: boolean) => neg ? '!=' : '=',
+        before: () => '<',
+        after: () => '>',
     }
     if (!(op in operationMap)) {
         throw new Error(`Unsupported operation: ${op}`)
@@ -49,7 +51,7 @@ export function getPercentageFromWeight(weight: number) {
     return weight / 100000
 }
 
-export function buildTargetingRules (
+export function buildTargetingRules(
     feature: LDFeature,
     environmentKey: string,
     audienceImport: LDAudienceImporter


### PR DESCRIPTION
- map before to `<` and after to `>`
- update readme with instructions for users who are importing
- LD already stores the dates as numbers
<img width="405" alt="image" src="https://user-images.githubusercontent.com/98763537/218876310-14295085-af03-4fe6-a183-8548908f16d6.png">
