### PR TITLE
[fix] map ld values to string for user filter

### DIFF
--- a/src/utils/DevCycle/targeting.test.ts
+++ b/src/utils/DevCycle/targeting.test.ts
@@ -33,7 +33,13 @@ describe('createUserFilters', () => {
         })
     })
 
-    test.each([['usa'], ['zz']])('catch errors thrown with invalid data', (values) => {
-        expect(() => createUserFilter('country', 'or', JSON.parse(values))).toThrow()
+    test.each([['usa'], ['zz'], ['111'], [111], [true]])('catch errors thrown with invalid data', (values) => {
+        expect(() => createUserFilter('country', 'or', [values])).toThrow()
+    })
+
+    test.each([['country', 'ca'], ['user_id', 123], ['email', true]])
+    ('values result should be string[] if subTypes are "country", "user_id", or "email"', (subType, value) => {
+        const result = createUserFilter(subType, 'or', [value])
+        expect(typeof result.values[0]).toBe('string')
     })
 })

--- a/src/utils/DevCycle/targeting.ts
+++ b/src/utils/DevCycle/targeting.ts
@@ -1,19 +1,27 @@
 import * as countries from 'i18n-iso-countries'
 const countryCodes = countries.getAlpha2Codes()
 
-export function createUserFilter(subType: string, comparator: string, values: string[]) {
-    let normalizedValue = values
+
+export function createUserFilter(subType: string, comparator: string, values: any[]) {
+    const stringifySubTypes = ['user_id', 'country', 'email']
+    let normalizedValues = values
+
+    if (stringifySubTypes.includes(subType)) {
+        normalizedValues = normalizedValues.map(value => value.toString())
+    }
+
     if (subType === 'country') {
-        if (values.some((value) => value.length !== 2 || countryCodes[(value.toUpperCase())] === undefined)) {
+        if (normalizedValues.some((value) => value.length !== 2 || countryCodes[(value.toUpperCase())] === undefined)) {
             throw new Error(`Country values should be 2-letter ISO codes: ${values.join(', ')}`)
         }
-        normalizedValue = values.map((value) => value.toUpperCase())
+        normalizedValues = normalizedValues.map((value) => value.toUpperCase())
     }
+    
     return {
         type: 'user',
         subType,
         comparator,
-        values: normalizedValue
+        values: normalizedValues
     }
 }
 


### PR DESCRIPTION
- map ld values to `string` for dvc user filter as ld accepts different types (bool, num, string) for most of their values