### PR TITLE
[feat] Infer environment type if possible

### DIFF
--- a/src/resources/environments/LDEnvironmentImporter.ts
+++ b/src/resources/environments/LDEnvironmentImporter.ts
@@ -1,19 +1,36 @@
 import { DVC } from '../../api'
 import { ParsedImporterConfig } from '../../configs'
-import { EnvironmentResponse } from '../../types/DevCycle'
+import { EnvironmentPayload, EnvironmentResponse, EnvironmentType } from '../../types/DevCycle'
 import { Environments as LDEnvironments, Environment as LDEnvironment } from '../../types/LaunchDarkly'
 import { promptToGetEnvironmentType } from './utils'
 
 export class LDEnvironmentImporter {
     private config: ParsedImporterConfig
+    environmentsByKey: Record<string, EnvironmentResponse> = {}
 
     constructor(config: ParsedImporterConfig) {
         this.config = config
     }
 
-    private async getEnvironmentPayload(environment: LDEnvironment) {
+    private async getExistingEnvironmentByKey(projectKey: string) {
+        this.environmentsByKey = await DVC.getEnvironments(projectKey).then((environments) => (
+            environments.reduce((map: Record<string, EnvironmentResponse>, environment) => {
+                map[environment.key] = environment
+                return map
+            }, {})
+        ))
+    }
+
+    private async getEnvironmentPayload(environment: LDEnvironment): Promise<EnvironmentPayload> {
         const { key, name, color } = environment
-        const type = await promptToGetEnvironmentType(key)
+        let type
+        if (this.environmentsByKey[key]) {
+            type = this.environmentsByKey[key].type
+        } else if ((<any>Object).values(EnvironmentType).includes(key)) {
+            type = key
+        } else {
+            type = await promptToGetEnvironmentType(key)
+        }
         const environmentPayload = {
             key,
             name,
@@ -25,36 +42,27 @@ export class LDEnvironmentImporter {
 
     async import(environments: LDEnvironments) {
         const { projectKey, overwriteDuplicates } = this.config
-    
-        const environmentsByKey = await DVC.getEnvironments(projectKey).then((environments) => (
-            environments.reduce((map: Record<string, EnvironmentResponse>, environment) => {
-                map[environment.key] = environment
-                return map
-            }, {})
-        ))
+        await this.getExistingEnvironmentByKey(projectKey)
     
         for (const environment of environments.items) {
             const { key } = environment
-            const isDuplicate = Boolean(environmentsByKey[key])
+            const isDuplicate = Boolean(this.environmentsByKey[key])
     
             if (!isDuplicate) {
                 const environmentPayload = await this.getEnvironmentPayload(environment)
     
-                environmentsByKey[key] = await DVC.createEnvironment(projectKey, environmentPayload)
+                this.environmentsByKey[key] = await DVC.createEnvironment(projectKey, environmentPayload)
                 console.log(`Creating environment "${key}" in DevCycle`)
             } else if (overwriteDuplicates) {
                 const environmentPayload = await this.getEnvironmentPayload(environment)
     
-                environmentsByKey[key] = await DVC.updateEnvironment(projectKey, key, environmentPayload)
+                this.environmentsByKey[key] = await DVC.updateEnvironment(projectKey, key, environmentPayload)
                 console.log(`Updating environment "${key}" in DevCycle`)
             } else {
                 console.log(`Skipping environment "${key}" creation because it already exists`)
             }
         }
     
-        return {
-            environmentsByKey
-        }
-    
+        return this.environmentsByKey
     }
 }


### PR DESCRIPTION
- If the environment already exists, use the existing type
- If the environment key matches one of the environment types, use that as the type
- Otherwise prompt the user to select a type