### PR TITLE
[feat] Add optional targetProjectKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ By default the config is read from `config.json` in the project root, this can b
 - <b>dvcClientSecret</b>: <i>string</i>
   - DevCycle client secret, used for fetching API credentials
   - Equivalent env var: DVC_CLIENT_SECRET
-- <b>projectKey</b>: <i>string</i>
-  - LaunchDarkly's project key, a project will be created with the same details in DevCycle
-  - Equivalent env var: PROJECT_KEY
+- <b>sourceProjectKey</b>: <i>string</i>
+  - LaunchDarkly's project key, resources will be pulled from this project
+  - Equivalent env var: SOURCE_PROJECT_KEY
 
 ### Optional
-
+- <b>targetProjectKey</b>: <i>string</i>
+  - A DevCycle project key, resources will be created within this project. A project will be created with this key if it does not already exist.
+  - If not specified, the target project key will be used
+  - Equivalent env var: TARGET_PROJECT_KEY
 - <b>includeFeatures</b>: <i>string[]</i>
   - An array of LD feature flag keys to be imported. By default, the importer will attempt to migrate all features.
   - Equivalent env var: INCLUDE_FEATURES
@@ -56,7 +59,7 @@ Sample config.json
   "ldAccessToken": "api-key",
   "dvcClientId": "clientId",
   "dvcClientSecret": "clientSecret",
-  "projectKey": "project-key",
+  "sourceProjectKey": "project-key",
   "includeFeatures": ["feat-1", "feat-2"],
   "excludeFeatures": [],
   "overwriteDuplicates": false,
@@ -73,7 +76,7 @@ Sample .env file
 LD_ACCESS_TOKEN="api-key"
 DVC_CLIENT_ID="clientId"
 DVC_CLIENT_SECRET="clientSecret"
-PROJECT_KEY="project-key"
+SOURCE_PROJECT_KEY="project-key"
 INCLUDE_FEATURES=[feat-1,feat-2]
 EXCLUDE_FEATURES=[]
 OVERWRITE_DUPLICATES=false

--- a/src/api/__mocks__/MockResponses/index.ts
+++ b/src/api/__mocks__/MockResponses/index.ts
@@ -6,6 +6,7 @@ export const mockConfig = {
     ldAccessToken: '123',
     dvcClientId: 'dvcid',
     dvcClientSecret: 'dvcsecret',
-    projectKey: 'project-key',
+    sourceProjectKey: 'project-key',
+    targetProjectKey: 'target-project-key',
     overwriteDuplicates: false,
 }

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -2,8 +2,8 @@ import * as dotenv from 'dotenv'
 import fs from 'fs'
 
 export const getConfigs = (): ParsedImporterConfig => {
-
     dotenv.config()
+
     const defaultConfigsFilePath = './config.json'
     const configFilePath = process.env.CONFIG_FILE_PATH || defaultConfigsFilePath
     const configs = fs.existsSync(configFilePath)
@@ -16,12 +16,15 @@ export const getConfigs = (): ParsedImporterConfig => {
     if (process.env.LD_ACCESS_TOKEN) configs.ldAccessToken = process.env.LD_ACCESS_TOKEN
     if (process.env.DVC_CLIENT_ID) configs.dvcClientId = process.env.DVC_CLIENT_ID
     if (process.env.DVC_CLIENT_SECRET) configs.dvcClientSecret = process.env.DVC_CLIENT_SECRET
-    if (process.env.PROJECT_KEY) configs.projectKey = process.env.PROJECT_KEY
+    if (process.env.SOURCE_PROJECT_KEY) configs.sourceProjectKey = process.env.SOURCE_PROJECT_KEY
+    if (process.env.TARGET_PROJECT_KEY) configs.targetProjectKey = process.env.TARGET_PROJECT_KEY
     if (process.env.INCLUDE_FEATURES) configs.includeFeatures = parseMapFromArray(process.env.INCLUDE_FEATURES)
     if (process.env.EXCLUDE_FEATURES) configs.excludeFeatures = parseMapFromArray(process.env.EXCLUDE_FEATURES)
     if (process.env.OVERWRITE_DUPLICATES)
         configs.overwriteDuplicates = getOptionalBoolean(process.env.OVERWRITE_DUPLICATES)
     if (process.env.OPERATION_MAP) configs.operationMap = JSON.parse(process.env.OPERATION_MAP)
+
+    if (!configs.targetProjectKey) configs.targetProjectKey = configs.sourceProjectKey
 
     validateConfigs(configs)
 
@@ -35,8 +38,8 @@ const validateConfigs = (configs: ParsedImporterConfig) => {
         throw Error('dvcClientId cannot be empty')
     if (configs.dvcClientSecret === '' || configs.dvcClientSecret === undefined)
         throw Error('dvcClientSecret cannot be empty')
-    if (configs.projectKey === '' || configs.projectKey === undefined)
-        throw Error('projectKey cannot be empty')
+    if (configs.sourceProjectKey === '' || configs.sourceProjectKey === undefined)
+        throw Error('sourceProjectKey cannot be empty')
 }
 
 const parseMapFromArray = (value: string | string[] | undefined): Map<string, boolean> | undefined => {
@@ -73,8 +76,12 @@ export type ParsedImporterConfig = {
     dvcClientId: string,
     dvcClientSecret: string,
 
-    // DevCycle project key, features will be created within this project
-    projectKey: string,
+    // Source project key, features will be pulled from this project
+    sourceProjectKey: string,
+
+    // [Optional] DevCycle project key, features will be created within this project
+    // By default, the source project key will be used
+    targetProjectKey: string,
 
     // [Optional] A map of LD feature flag keys to be imported
     // By default, the importer will attempt to migrate all features

--- a/src/resources/audiences/LDAudienceImporter.test.ts
+++ b/src/resources/audiences/LDAudienceImporter.test.ts
@@ -11,7 +11,8 @@ const mockConfig = {
     ldAccessToken: '123',
     dvcClientId: 'dvcid',
     dvcClientSecret: 'dvcsecret',
-    projectKey: 'project-key',
+    sourceProjectKey: 'project-key',
+    targetProjectKey: 'target-project-key',
 }
 
 const mockDvcAudienceResponse = {
@@ -51,7 +52,7 @@ describe('LDAudienceImporter', () => {
         const createResponse = {
             ...mockDvcAudienceResponse,
             name: ldSegment.name,
-            key: config.projectKey,
+            key: config.targetProjectKey,
             filters: expectedFilters
         }
         mockLD.getSegments.mockResolvedValue({ items: [ldSegment] })
@@ -66,7 +67,7 @@ describe('LDAudienceImporter', () => {
         })
         expect(audienceImporter.errors).toEqual({})
         expect(mockDVC.createAudience).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             {
                 name: ldSegment.name,
                 key: `${ldSegment.key}-${envKey}`,
@@ -115,7 +116,7 @@ describe('LDAudienceImporter', () => {
         const updateResponse = {
             ...mockDvcAudienceResponse,
             name: ldSegment.name,
-            key: config.projectKey,
+            key: config.targetProjectKey,
             filters: expectedFilters
         }
         mockLD.getSegments.mockResolvedValue({ items: [ldSegment] })
@@ -130,7 +131,7 @@ describe('LDAudienceImporter', () => {
         })
         expect(audienceImporter.errors).toEqual({})
         expect(mockDVC.updateAudience).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             `${ldSegment.key}-${envKey}`,
             {
                 name: ldSegment.name,

--- a/src/resources/environments/LDEnvironmentImporter.test.ts
+++ b/src/resources/environments/LDEnvironmentImporter.test.ts
@@ -57,7 +57,7 @@ describe('LDEnvironmentImporter', () => {
 
         const { key, name, color } = mockLDEnvironment.items[0]
         expect(mockDVC.createEnvironment).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             {
                 key,
                 name,
@@ -75,7 +75,7 @@ describe('LDEnvironmentImporter', () => {
 
         const { key, name, color } = mockLDEnvironment.items[0]
         expect(mockDVC.updateEnvironment).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             key,
             {
                 key,
@@ -102,7 +102,7 @@ describe('LDEnvironmentImporter', () => {
         await importEnvironment()
 
         expect(mockDVC.updateEnvironment).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             mockDvcEnvironmentResponse.key,
             expect.objectContaining({
                 type: mockDvcEnvironmentResponse.type
@@ -117,7 +117,7 @@ describe('LDEnvironmentImporter', () => {
         await importEnvironment()
 
         expect(mockDVC.createEnvironment).toHaveBeenCalledWith(
-            config.projectKey,
+            config.targetProjectKey,
             expect.objectContaining({
                 type: 'production'
             })

--- a/src/resources/environments/LDEnvironmentImporter.ts
+++ b/src/resources/environments/LDEnvironmentImporter.ts
@@ -42,8 +42,8 @@ export class LDEnvironmentImporter {
     }
 
     async import(environments: LDEnvironments) {
-        const { projectKey, overwriteDuplicates } = this.config
-        await this.getExistingEnvironmentByKey(projectKey)
+        const { targetProjectKey, overwriteDuplicates } = this.config
+        await this.getExistingEnvironmentByKey(targetProjectKey)
     
         for (const environment of environments.items) {
             const key = formatKey(environment.key)
@@ -52,12 +52,12 @@ export class LDEnvironmentImporter {
             if (!isDuplicate) {
                 const environmentPayload = await this.getEnvironmentPayload(environment)
     
-                this.environmentsByKey[key] = await DVC.createEnvironment(projectKey, environmentPayload)
+                this.environmentsByKey[key] = await DVC.createEnvironment(targetProjectKey, environmentPayload)
                 console.log(`Creating environment "${key}" in DevCycle`)
             } else if (overwriteDuplicates) {
                 const environmentPayload = await this.getEnvironmentPayload(environment)
     
-                this.environmentsByKey[key] = await DVC.updateEnvironment(projectKey, key, environmentPayload)
+                this.environmentsByKey[key] = await DVC.updateEnvironment(targetProjectKey, key, environmentPayload)
                 console.log(`Updating environment "${key}" in DevCycle`)
             } else {
                 console.log(`Skipping environment "${key}" creation because it already exists`)

--- a/src/resources/features/CustomPropertiesImporter.ts
+++ b/src/resources/features/CustomPropertiesImporter.ts
@@ -45,8 +45,8 @@ export class CustomPropertiesImporter {
     }
 
     private async importCustomProperties() {
-        const { overwriteDuplicates, projectKey } = this.config
-        const existingCustomPropertiesMap = await DVC.getCustomPropertiesForProject(projectKey)
+        const { overwriteDuplicates, targetProjectKey } = this.config
+        const existingCustomPropertiesMap = await DVC.getCustomPropertiesForProject(targetProjectKey)
             .then((existingCustomProperties) => existingCustomProperties.reduce((map: Record<string, CustomProperties>, cp) => {
                 map[cp.propertyKey] = cp
                 return map
@@ -61,10 +61,10 @@ export class CustomPropertiesImporter {
             const isDuplicate = existingCustomPropertiesMap[customPropertyToCreate.propertyKey] !== undefined
             try {
                 if (!isDuplicate) {
-                    await DVC.createCustomProperty(projectKey, customPropertyToCreate)
+                    await DVC.createCustomProperty(targetProjectKey, customPropertyToCreate)
                     console.log(`Creating custom property "${customPropertyToCreate.propertyKey}"`)
                 } else if (overwriteDuplicates) {
-                    await DVC.updateCustomProperty(projectKey, customPropertyToCreate)
+                    await DVC.updateCustomProperty(targetProjectKey, customPropertyToCreate)
                     console.log(`Updating custom property "${customPropertyToCreate.propertyKey}"`)
                 }
             } catch (e) {

--- a/src/resources/features/LDFeatureImporter.test.ts
+++ b/src/resources/features/LDFeatureImporter.test.ts
@@ -180,7 +180,7 @@ describe('LDFeatureImporter', () => {
                 errored: {},
             })
             expect(mockDVC.createFeature).toHaveBeenCalledWith(
-                mockConfig.projectKey,
+                mockConfig.targetProjectKey,
                 featuresToImport['feature-key'].feature
             )
             expect(mockDVC.updateFeature).not.toHaveBeenCalled()
@@ -205,7 +205,7 @@ describe('LDFeatureImporter', () => {
                 errored: {},
             })
             expect(mockDVC.updateFeature).toHaveBeenCalledWith(
-                mockConfig.projectKey,
+                mockConfig.targetProjectKey,
                 featuresToImport['feature-key'].feature
             )
             expect(mockDVC.createFeature).not.toHaveBeenCalled()

--- a/src/resources/projects/LDProjectImporter.test.ts
+++ b/src/resources/projects/LDProjectImporter.test.ts
@@ -10,7 +10,8 @@ const mockConfig = {
     ldAccessToken: '123',
     dvcClientId: 'dvcid',
     dvcClientSecret: 'dvcsecret',
-    projectKey: 'project-key',
+    sourceProjectKey: 'project-key',
+    targetProjectKey: 'project-key',
 }
 
 const mockDvcProjectResponse = {

--- a/src/resources/projects/LDProjectImporter.ts
+++ b/src/resources/projects/LDProjectImporter.ts
@@ -13,12 +13,12 @@ export class LDProjectImporter {
     }
 
     async import() {
-        const { projectKey, overwriteDuplicates } = this.config
-        const ldProject = await LD.getProject(projectKey)
+        const { sourceProjectKey, targetProjectKey, overwriteDuplicates } = this.config
+        const ldProject = await LD.getProject(sourceProjectKey)
     
         let isDuplicate
         try {
-            this.dvcProject = await DVC.getProject(projectKey)
+            this.dvcProject = await DVC.getProject(targetProjectKey)
             isDuplicate = true
         } catch (e) {
             isDuplicate = false
@@ -26,15 +26,15 @@ export class LDProjectImporter {
     
         const projectPayload = {
             name: ldProject.name,
-            key: ldProject.key
+            key: targetProjectKey
         }
     
         if (!isDuplicate) {
             this.dvcProject = await DVC.createProject(projectPayload)
             console.log(`Creating project "${projectPayload.key}" in DevCycle`)
         } else if (overwriteDuplicates) {
-            this.dvcProject = await DVC.updateProject(projectKey, projectPayload)
-            console.log(`Updating project "${projectKey}" in DevCycle`)
+            this.dvcProject = await DVC.updateProject(targetProjectKey, projectPayload)
+            console.log(`Updating project "${targetProjectKey}" in DevCycle`)
         } else {
             console.log('Skipping project creation because it already exists')
         }


### PR DESCRIPTION
- Update `projectKey` to `sourceProjectKey`
- Add optional `targetProjectKey` which defaults to `targetProjectKey`
- Source project key is used to pull from LD, and target project key is used to create resources in DVC